### PR TITLE
fix: node 18 native fetch support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.5.81",
       "license": "MIT",
       "dependencies": {
+        "@pollyjs/adapter-fetch": "6.0.5",
         "@pollyjs/adapter-node-http": "6.0.5",
         "@pollyjs/core": "6.0.5",
         "@pollyjs/persister-fs": "6.0.5",
@@ -1465,6 +1466,17 @@
       "integrity": "sha512-xiAdK+ZBABWpXvUVdcgvZpGI0drix8uy6KFWZr3pVvzKWfr6VyKObd6J6alxA8LG/kQ3BL350fIDia8UIcvwrw==",
       "dependencies": {
         "@pollyjs/utils": "^6.0.1"
+      }
+    },
+    "node_modules/@pollyjs/adapter-fetch": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@pollyjs/adapter-fetch/-/adapter-fetch-6.0.5.tgz",
+      "integrity": "sha512-Ns+LOrVrnIrGSWKT/pkGCsy9n731TcbYcU29EwObw02snutZkOUzJTp96JYDJOlDRGJ6ltPkOjgaSpwQtjA4BQ==",
+      "dependencies": {
+        "@pollyjs/adapter": "^6.0.4",
+        "@pollyjs/utils": "^6.0.1",
+        "detect-node": "^2.1.0",
+        "to-arraybuffer": "^1.0.1"
       }
     },
     "node_modules/@pollyjs/adapter-node-http": {
@@ -3500,6 +3512,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -10060,6 +10077,11 @@
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
+    "node_modules/to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA=="
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -11735,6 +11757,17 @@
         "@pollyjs/utils": "^6.0.1"
       }
     },
+    "@pollyjs/adapter-fetch": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@pollyjs/adapter-fetch/-/adapter-fetch-6.0.5.tgz",
+      "integrity": "sha512-Ns+LOrVrnIrGSWKT/pkGCsy9n731TcbYcU29EwObw02snutZkOUzJTp96JYDJOlDRGJ6ltPkOjgaSpwQtjA4BQ==",
+      "requires": {
+        "@pollyjs/adapter": "^6.0.4",
+        "@pollyjs/utils": "^6.0.1",
+        "detect-node": "^2.1.0",
+        "to-arraybuffer": "^1.0.1"
+      }
+    },
     "@pollyjs/adapter-node-http": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@pollyjs/adapter-node-http/-/adapter-node-http-6.0.5.tgz",
@@ -13321,6 +13354,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "diff": {
       "version": "4.0.2",
@@ -18231,6 +18269,11 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@pollyjs/adapter-node-http": "6.0.5",
+    "@pollyjs/adapter-fetch": "6.0.5",
     "@pollyjs/core": "6.0.5",
     "@pollyjs/persister-fs": "6.0.5",
     "@types/pollyjs__adapter-node-http": "2.0.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import FetchAdapter from '@pollyjs/adapter-fetch'
 import NodeHttpAdapter from '@pollyjs/adapter-node-http'
 import { PollyConfig } from '@pollyjs/core'
 import FSPersister from '@pollyjs/persister-fs'
@@ -38,7 +39,7 @@ export class JestPollyConfigService {
     const recordingsDirectory = path.join(recordingsRoot, '__recordings__')
 
     return {
-      adapters: [NodeHttpAdapter],
+      adapters: [FetchAdapter],
       persister: FSPersister,
       persisterOptions: {
         keepUnusedRequests: false,

--- a/src/jest-polly.test.ts
+++ b/src/jest-polly.test.ts
@@ -4,10 +4,13 @@
 import './jest-polly'
 
 import http from 'node:http'
-import fetch from 'node-fetch'
 
 import { jestPollyConfigService } from './config'
 import { APPLICATION_JSON_MIME } from './constants'
+// import fetch from 'node-fetch'
+
+// @ts-ignore
+const { fetch } = global
 
 const SECRET_VALUE = 'foobarbaz'
 const SECRET_REPLACER = 'x'

--- a/src/jest-polly.ts
+++ b/src/jest-polly.ts
@@ -1,3 +1,4 @@
+import FetchAdapter from '@pollyjs/adapter-fetch'
 import NodeHttpAdapter from '@pollyjs/adapter-node-http'
 import { Polly } from '@pollyjs/core'
 import FSPersister from '@pollyjs/persister-fs'


### PR DESCRIPTION
This is just a quick POC, not an actual final implementation.

Looks like there is an issue on the Polly side:

Tests throw with:

```
    TypeError: Cannot assign to read only property 'Request' of object '[object global]'

      32 | // eslint-disable-next-line jest/require-top-level-describe
      33 | beforeEach(() => {
    > 34 |   jestPollyContext.polly.configure(jestPollyConfigService.config)
         |                          ^
      35 |   jestPollyContext.polly.server
      36 |     .any()
      37 |     .on('beforePersist', (request, recording: PollyRecording) => {

      at FetchAdapter.onConnect (node_modules/@pollyjs/adapter-fetch/src/index.js:53:5)
          at Array.forEach (<anonymous>)
      at Object.<anonymous> (src/jest-polly.ts:34:26)
```

Which seems to be coming from here:

https://github.com/Netflix/pollyjs/blob/2d7f0f33d9f552e78f0dfe81179751b4692357be/packages/%40pollyjs/adapter-fetch/src/index.js#L53

Closes #342